### PR TITLE
feat: multi-select strategies for trades

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -106,6 +106,7 @@
   --sidebar-accent-foreground: oklch(0.4 0.1 260);
   --sidebar-border: oklch(0.92 0.005 285);
   --sidebar-ring: oklch(0.55 0.2 260);
+  navigation: auto;
 }
 
 .dark {

--- a/lib/components/custom/AddTradeModal.tsx
+++ b/lib/components/custom/AddTradeModal.tsx
@@ -26,6 +26,7 @@ import {
 import { Textarea } from "@/lib/components/ui/textarea";
 import type { Strategy } from "@/lib/types/trade.type";
 import AddStrategyModal from "./AddStrategyModal";
+import StrategyMultiSelect from "./StrategyMultiSelect";
 
 export default function AddTradeModal() {
 	const [open, setOpen] = useState(false);
@@ -33,7 +34,7 @@ export default function AddTradeModal() {
 	const [loading, setLoading] = useState(false);
 
 	const [strategies, setStrategies] = useState<Strategy[]>([]);
-	const [selectedStrategy, setSelectedStrategy] = useState<string>("");
+	const [selectedStrategies, setSelectedStrategies] = useState<string[]>([]);
 	const [tradeType, setTradeType] = useState<string>("BUY");
 	const [status, setStatus] = useState<string>("OPEN");
 
@@ -47,7 +48,7 @@ export default function AddTradeModal() {
 		setStrategies((prev) =>
 			[...prev, strategy].sort((a, b) => a.name.localeCompare(b.name)),
 		);
-		setSelectedStrategy(strategy.id);
+		setSelectedStrategies((prev) => [...prev, strategy.id]);
 	}
 
 	function handleOpenChange(next: boolean) {
@@ -56,7 +57,7 @@ export default function AddTradeModal() {
 			// reset controlled fields on close
 			setTradeType("BUY");
 			setStatus("OPEN");
-			setSelectedStrategy("");
+			setSelectedStrategies([]);
 		}
 	}
 
@@ -68,7 +69,8 @@ export default function AddTradeModal() {
 		// inject controlled select values
 		formData.set("trade_type", tradeType);
 		formData.set("status", status);
-		if (selectedStrategy) formData.set("strategy", selectedStrategy);
+		formData.delete("strategy");
+		for (const id of selectedStrategies) formData.append("strategy", id);
 
 		const res = await createTrade(formData);
 		setLoading(false);
@@ -282,45 +284,12 @@ export default function AddTradeModal() {
 										(optional)
 									</span>
 								</label>
-								<div className="flex gap-2">
-									<Select
-										value={selectedStrategy}
-										onValueChange={setSelectedStrategy}
-									>
-										<SelectTrigger className="flex-1">
-											<SelectValue placeholder="Select a strategy..." />
-										</SelectTrigger>
-										<SelectContent>
-											{strategies.length === 0 ? (
-												<div className="px-2 py-3 text-sm text-muted-foreground text-center">
-													No strategies yet
-												</div>
-											) : (
-												strategies.map((s) => (
-													<SelectItem key={s.id} value={s.id}>
-														<span className="flex items-center gap-2">
-															<span
-																className="inline-block size-2.5 rounded-full shrink-0"
-																style={{ backgroundColor: s.color ?? "#000" }}
-															/>
-															{s.name}
-														</span>
-													</SelectItem>
-												))
-											)}
-										</SelectContent>
-									</Select>
-
-									<Button
-										type="button"
-										variant="outline"
-										size="icon"
-										onClick={() => setStrategyModalOpen(true)}
-										title="Create new strategy"
-									>
-										<Plus className="size-4" />
-									</Button>
-								</div>
+								<StrategyMultiSelect
+								strategies={strategies}
+								selected={selectedStrategies}
+								onChange={setSelectedStrategies}
+								onAddClick={() => setStrategyModalOpen(true)}
+							/>
 							</div>
 
 							<div className="space-y-2">

--- a/lib/components/custom/Sidebar.tsx
+++ b/lib/components/custom/Sidebar.tsx
@@ -9,7 +9,6 @@ import {
   Wallet,
   History,
   Settings,
-  LogOut,
   BookOpen,
 } from "lucide-react";
 
@@ -39,7 +38,7 @@ export function Sidebar() {
       </div>
 
       <div className="flex-1 px-4 py-4">
-        <nav className="flex flex-col gap-2">
+        <nav className="flex flex-col gap-2 sidebar-nav">
           {links.map((link) => {
             const Icon = link.icon;
             const isActive =
@@ -51,11 +50,12 @@ export function Sidebar() {
                 key={link.href}
                 href={link.href}
                 className={cn(
-                  "flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-all duration-200",
+                  "sidebar-nav-active flex items-center gap-3 relative rounded-lg px-3 py-2.5 text-sm font-medium transition-all duration-200",
                   isActive
                     ? "bg-sidebar-primary text-sidebar-primary-foreground shadow-sm"
                     : "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground text-muted-foreground",
                 )}
+                data-active={isActive}
               >
                 <Icon
                   className={cn(

--- a/lib/components/custom/StrategyMultiSelect.tsx
+++ b/lib/components/custom/StrategyMultiSelect.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { Check, ChevronDown, Plus } from "lucide-react";
+import { Button } from "@/lib/components/ui/button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@/lib/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+import type { Strategy } from "@/lib/types/trade.type";
+
+interface StrategyMultiSelectProps {
+	strategies: Strategy[];
+	selected: string[];
+	onChange: (ids: string[]) => void;
+	onAddClick: () => void;
+}
+
+export default function StrategyMultiSelect({
+	strategies,
+	selected,
+	onChange,
+	onAddClick,
+}: StrategyMultiSelectProps) {
+	function toggle(id: string) {
+		onChange(
+			selected.includes(id) ? selected.filter((s) => s !== id) : [...selected, id],
+		);
+	}
+
+	const label = (() => {
+		if (selected.length === 0) return "Select strategies...";
+		if (selected.length === 1) {
+			return strategies.find((s) => s.id === selected[0])?.name ?? "1 selected";
+		}
+		return `${selected.length} strategies`;
+	})();
+
+	return (
+		<div className="flex gap-2">
+			<DropdownMenu>
+				<DropdownMenuTrigger asChild>
+					<Button
+						type="button"
+						variant="outline"
+						className="flex-1 justify-between font-normal"
+					>
+						<span className="flex items-center gap-1.5 flex-wrap min-w-0">
+							{selected.length > 0 && selected.length <= 3 ? (
+								selected.map((id) => {
+									const s = strategies.find((s) => s.id === id);
+									if (!s) return null;
+									return (
+										<span key={id} className="flex items-center gap-1">
+											<span
+												className="inline-block size-2 rounded-full shrink-0"
+												style={{ backgroundColor: s.color ?? "#888" }}
+											/>
+											<span className="text-sm">{s.name}</span>
+										</span>
+									);
+								})
+							) : (
+								<span className="text-muted-foreground">{label}</span>
+							)}
+						</span>
+						<ChevronDown className="ml-2 size-4 shrink-0 opacity-50" />
+					</Button>
+				</DropdownMenuTrigger>
+				<DropdownMenuContent className="w-56" align="start">
+					{strategies.length === 0 ? (
+						<div className="px-2 py-3 text-sm text-muted-foreground text-center">
+							No strategies yet
+						</div>
+					) : (
+						strategies.map((s) => (
+							<DropdownMenuItem
+								key={s.id}
+								onSelect={(e) => {
+									e.preventDefault();
+									toggle(s.id);
+								}}
+								className="flex items-center gap-2 cursor-pointer"
+							>
+								<span
+									className="inline-block size-2.5 rounded-full shrink-0"
+									style={{ backgroundColor: s.color ?? "#888" }}
+								/>
+								<span className="flex-1">{s.name}</span>
+								<Check
+									className={cn(
+										"size-4 shrink-0",
+										selected.includes(s.id) ? "opacity-100" : "opacity-0",
+									)}
+								/>
+							</DropdownMenuItem>
+						))
+					)}
+				</DropdownMenuContent>
+			</DropdownMenu>
+
+			<Button
+				type="button"
+				variant="outline"
+				size="icon"
+				onClick={onAddClick}
+				title="Create new strategy"
+			>
+				<Plus className="size-4" />
+			</Button>
+		</div>
+	);
+}

--- a/lib/components/custom/TradeTable.tsx
+++ b/lib/components/custom/TradeTable.tsx
@@ -102,19 +102,23 @@ const columns = [
       <span className="text-xs text-muted-foreground">{info.getValue()}</span>
     ),
   }),
-  columnHelper.accessor("strategy_name", {
+  columnHelper.accessor("strategies", {
     header: "Strategy",
     cell: (info) => {
-      const name = info.getValue();
-      const color = info.row.original.strategy_color;
-      if (!name) return <span className="text-muted-foreground">—</span>;
+      const strategies = info.getValue();
+      if (!strategies.length)
+        return <span className="text-muted-foreground">—</span>;
       return (
-        <span className="flex items-center gap-1.5">
-          <span
-            className="inline-block size-2 rounded-full shrink-0"
-            style={{ backgroundColor: color ?? "#888" }}
-          />
-          <span className="text-sm">{name}</span>
+        <span className="flex flex-wrap gap-1">
+          {strategies.map((s) => (
+            <span key={s.id} className="flex items-center gap-1">
+              <span
+                className="inline-block size-2 rounded-full shrink-0"
+                style={{ backgroundColor: s.color ?? "#888" }}
+              />
+              <span className="text-sm">{s.name}</span>
+            </span>
+          ))}
         </span>
       );
     },

--- a/lib/db/migrations/001_trade_strategies.sql
+++ b/lib/db/migrations/001_trade_strategies.sql
@@ -1,0 +1,18 @@
+-- Migration: move single-strategy FK to trade_strategies join table
+
+-- 1. Create join table if it doesn't exist yet
+CREATE TABLE IF NOT EXISTS trade_strategies (
+    trade_id   UUID NOT NULL REFERENCES trades(id) ON DELETE CASCADE,
+    strategy_id UUID NOT NULL REFERENCES strategies(id) ON DELETE CASCADE,
+    PRIMARY KEY (trade_id, strategy_id)
+);
+
+-- 2. Migrate existing single-strategy values into the join table
+INSERT INTO trade_strategies (trade_id, strategy_id)
+SELECT id, strategy
+FROM trades
+WHERE strategy IS NOT NULL
+ON CONFLICT DO NOTHING;
+
+-- 3. Drop the old single-strategy column
+ALTER TABLE trades DROP COLUMN IF EXISTS strategy;

--- a/lib/db/schema.sql
+++ b/lib/db/schema.sql
@@ -39,10 +39,13 @@ CREATE TABLE trades (
     fees DECIMAL(15, 4) DEFAULT 0,
     net_pnl DECIMAL(15, 4) DEFAULT 0,
     notes TEXT,
-    strategy UUID REFERENCES strategies(id) ON DELETE
-    SET NULL,
-        created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-        updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+CREATE TABLE trade_strategies (
+    trade_id UUID NOT NULL REFERENCES trades(id) ON DELETE CASCADE,
+    strategy_id UUID NOT NULL REFERENCES strategies(id) ON DELETE CASCADE,
+    PRIMARY KEY (trade_id, strategy_id)
 );
 CREATE INDEX idx_trades_user_id ON trades (user_id);
 CREATE INDEX idx_trades_symbol ON trades (symbol);

--- a/lib/types/trade.type.ts
+++ b/lib/types/trade.type.ts
@@ -1,3 +1,9 @@
+export type StrategyRef = {
+  id: string;
+  name: string;
+  color: string;
+};
+
 export type TradeWithJoins = {
   id: string;
   user_id: string;
@@ -19,10 +25,7 @@ export type TradeWithJoins = {
   net_pnl: number;
 
   notes: string | null;
-  strategy: string | null;
-
-  strategy_name: string | null;
-  strategy_color: string | null;
+  strategies: StrategyRef[];
 
   created_at: string;
   updated_at: string;


### PR DESCRIPTION
## Summary

- Replace single `strategy` UUID FK on `trades` with a `trade_strategies` many-to-many join table
- Add `StrategyMultiSelect` component — dropdown with checkboxes, stays open on selection, shows colored dot + name inline
- Update `AddTradeModal` and `EditTradeModal` to use multi-select
- Update `TradeTable` strategy column to render multiple strategy badges
- Update server actions (`getTrades`, `createTrade`, `updateTrade`) to read/write the join table
- Update `lib/utils/export.ts` — CSV joins strategy names with `;`, JSON exports full `{id, name, color}` objects
- Add `lib/db/migrations/001_trade_strategies.sql` — run once to migrate existing data and drop old column

## Test plan

- [x] Run migration SQL against the database
- [ ] Create a trade with multiple strategies — verify all are saved
- [x] Edit a trade and change strategies — verify old ones are replaced
- [x] Verify strategy column in trade table shows all badges
- [x] Export trades as CSV and JSON — verify strategies field is correct
- [x] Create a new strategy inline from the multi-select — verify it auto-selects